### PR TITLE
Swapping printing library for drawing tables to the file

### DIFF
--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -20,10 +20,10 @@
     <Compile Include="ScenarioRunner.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="HdrHistogram" Version="2.5.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.0.0" />
-    <PackageReference Include="FsPrettyTable" Version="0.1.0" />
+    <PackageReference Include="HdrHistogram" Version="2.5.0"/>
+    <PackageReference Include="Serilog" Version="2.7.1"/>
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>
+    <PackageReference Include="TaskBuilder.fs" Version="2.0.0"/>
+    <PackageReference Include="ConsoleTables" Version="2.2.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
```
Scenario: Test HTTP (https://github.com) with 100 concurrent users, execution time: 00:00:10

+-----------+-------------------+
| FLOW NAME | CONCURRENT COPIES |
+-----------+-------------------+
| GET flow  | 100               |
+-----------+-------------------+


+---------+---------------------------------------+
| STEP NO | STEP NAME                             |
+---------+---------------------------------------+
| 1       | GET github.com/VIP-Logic/NBomber html |
+---------+---------------------------------------+


+---------+---------------+----------+------------+-----------------+-----+-----+------+------+----------------+-----+
| step No | request_count | ok_count | fail_count | exception_count | RPS | min | mean | max  | percentile 50% | 70% |
+---------+---------------+----------+------------+-----------------+-----+-----+------+------+----------------+-----+
| 1       | 334           | 0        | 334        | 0               | 33  | 77  | 307  | 8815 | 120            | 143 |
+---------+---------------+----------+------------+-----------------+-----+-----+------+------+----------------+-----+
```