### PR TITLE
Improving flows table report

### DIFF
--- a/src/NBomber/Reporting.fs
+++ b/src/NBomber/Reporting.fs
@@ -17,23 +17,27 @@ type StepInfo = {
     FailCount: int
     ExceptionCount: ExceptionCount
 } with
-  static member Create(stepName, responseResults: List<StepResult*Latency>, 
+    static member Create(stepName, responseResults: List<StepResult*Latency>, 
                                  exceptions: (Option<exn>*ExceptionCount)) =     
     
-    let results = responseResults.ToArray()
-    
-    { StepName = stepName 
-      Latencies = results |> Array.map(snd)
-      ThrownException = fst(exceptions)                                  
-      OkCount = results 
-                |> Array.map(fst)
-                |> Array.filter(fun stRes -> stRes = StepResult.Ok)
-                |> Array.length                                  
-      FailCount = results 
-                  |> Array.map(fst)
-                  |> Array.filter(fun stRes -> stRes = StepResult.Fail)
-                  |> Array.length
-      ExceptionCount = snd(exceptions) }
+        let results = responseResults.ToArray()
+        
+        { StepName = stepName 
+          Latencies = results |> Array.map(snd)
+          ThrownException = fst(exceptions)                                  
+          OkCount = results 
+                    |> Array.map(fst)
+                    |> Array.filter(fun stRes -> stRes = StepResult.Ok)
+                    |> Array.length                                  
+          FailCount = results 
+                      |> Array.map(fst)
+                      |> Array.filter(fun stRes -> stRes = StepResult.Fail)
+                      |> Array.length
+          ExceptionCount = snd(exceptions) }
+
+    static member ToString(stepInfo: StepInfo) =
+        String.Format("{0} (OK:{1}, Failed:{2}, Exceptions:{3})",
+            stepInfo.Latencies.Length, stepInfo.OkCount, stepInfo.FailCount, stepInfo.ExceptionCount)
 
 type FlowInfo = {
     FlowName: string
@@ -85,30 +89,30 @@ type StepStats = {
 
 let buildReport (scenario: Scenario, flowInfo: FlowInfo[]) =        
     let header = String.Format("Scenario: {0}, execution time: {1}", scenario.ScenarioName, scenario.Duration.ToString())
-    let details = flowInfo |> Array.map(fun x -> printFlowTable(x, scenario.Duration)) |> String.concat ""    
+    let details = flowInfo |> Array.mapi(fun i x -> printFlowTable(x, scenario.Duration, i+1)) |> String.concat Environment.NewLine    
     header + Environment.NewLine + Environment.NewLine + details                 
 
-let printFlowTable (flowStats: FlowInfo, scenarioDuration: TimeSpan) =
+let printFlowTable (flowStats: FlowInfo, scenarioDuration: TimeSpan, flowCount: int) =
     
-    let stepsNames =        
-        flowStats.Steps
-        |> Array.mapi(fun index stats ->  String.Format("{0} - {1}", index + 1, stats.StepName))
-        |> String.concat Environment.NewLine
-    
-    let flowTable = ConsoleTable("flows", "steps", "concurrent copies")
-                        .AddRow(flowStats.FlowName, stepsNames, flowStats.ConcurrentCopies)
-                        .ToStringAlternative()    
-    
-    let stepTable = ConsoleTable("step no", "request_count", "ok_count", "fail_count",
-                                 "exception_count", "RPS", "min", "mean", "max",
-                                 "percentile 50%", "70%")
+    let consoleTableOptions = ConsoleTableOptions
+                                (Columns = [ String.Format("flow {0}: {1}", flowCount, flowStats.FlowName);
+                                        "steps"; String.Format("concurrent copies: {0}", flowStats.ConcurrentCopies)],
+                                EnableCount = false)
+
+    let flowTable = ConsoleTable(consoleTableOptions)
+       
+    flowStats.Steps
+        |> Array.iteri(fun index stats ->
+                        flowTable.AddRow("", String.Format("{0} - {1}", index + 1, stats.StepName), "") |> ignore)
+
+    let stepTable = ConsoleTable("step no", "requests", "RPS", "min", "mean", "max",
+                                 "50%", "70%")
     flowStats.Steps
     |> Array.mapi(fun i stInfo -> StepStats.Create(i + 1, stInfo, scenarioDuration))
-    |> Array.iter(fun s -> stepTable.AddRow(s.StepNo, s.Info.Latencies.Length, s.Info.OkCount,
-                                            s.Info.FailCount, s.Info.ExceptionCount,
+    |> Array.iter(fun s -> stepTable.AddRow(s.StepNo, StepInfo.ToString(s.Info),
                                             s.RPS, s.Min, s.Mean, s.Max, s.Percent50, s.Percent75) |> ignore)
     
-    flowTable + Environment.NewLine + stepTable.ToStringAlternative()
+    flowTable.ToString() + Environment.NewLine + stepTable.ToStringAlternative()
 
 let saveReport (report: string) = 
     Directory.CreateDirectory("reports") |> ignore


### PR DESCRIPTION
```
Scenario: Test MongoDb with 2 READ quries and 2000 docs, execution time: 00:00:10

 ----------------------------------------------------------------------------------------- 
 | flow 1: READ Users 1 | steps                                  | concurrent copies: 20 |
 ----------------------------------------------------------------------------------------- 
 |                      | 1 - read IsActive = true and TOP 500   |                       |
 ----------------------------------------------------------------------------------------- 
 |                      | 2 - read IsActive = false and TOP 1500 |                       |
 ----------------------------------------------------------------------------------------- 

+---------+--------------------------------------+-----+-----+------+-----+-----+-----+
| step no | requests                             | RPS | min | mean | max | 50% | 70% |
+---------+--------------------------------------+-----+-----+------+-----+-----+-----+
| 1       | 815 (OK:815, Failed:0, Exceptions:0) | 81  | 17  | 122  | 578 | 103 | 135 |
+---------+--------------------------------------+-----+-----+------+-----+-----+-----+
| 2       | 815 (OK:815, Failed:0, Exceptions:0) | 81  | 9   | 124  | 566 | 103 | 137 |
+---------+--------------------------------------+-----+-----+------+-----+-----+-----+

 -------------------------------------------------------------------------------- 
 | flow 2: READ Users 2 | steps                         | concurrent copies: 20 |
 -------------------------------------------------------------------------------- 
 |                      | 1 - read Age > 50 and TOP 100 |                       |
 -------------------------------------------------------------------------------- 

+---------+----------------------------------------+-----+-----+------+-----+-----+-----+
| step no | requests                               | RPS | min | mean | max | 50% | 70% |
+---------+----------------------------------------+-----+-----+------+-----+-----+-----+
| 1       | 3578 (OK:3578, Failed:0, Exceptions:0) | 357 | 3   | 56   | 448 | 46  | 60  |
+---------+----------------------------------------+-----+-----+------+-----+-----+-----+
```