### PR TITLE
Scenario Runner improvements and IAssertion interface

### DIFF
--- a/examples/NBomber.Examples.CSharp/Program.cs
+++ b/examples/NBomber.Examples.CSharp/Program.cs
@@ -3,6 +3,7 @@
 using NBomber.Examples.CSharp.Scenarios.Mongo;
 using NBomber.Examples.CSharp.Scenarios.Http;
 using NBomber.Examples.CSharp.Scenarios.PubSub;
+using NBomber.CSharp;
 
 namespace NBomber.Examples.CSharp
 {
@@ -11,10 +12,22 @@ namespace NBomber.Examples.CSharp
         static void Main(string[] args)
         {
             //var scenario = MongoScenario.BuildScenario();
-            //var scenario = HttpScenario.BuildScenario();
+            //var scenario = HttpScenario.BuildScenario();  
             var scenario = SimplePushScenario.BuildScenario();
 
-            ScenarioRunner.Run(scenario);            
+            var asserts = new [] {
+               Assert.ForScenario(stats => stats.OkCount > 95),
+               Assert.ForScenario(stats => stats.FailCount > 95),
+               Assert.ForScenario(stats => stats.ExceptionCount > 95),
+               Assert.ForScenario(stats => stats.OkCount >= 95),
+               Assert.ForTestFlow("Flow name 23", stats => stats.FailCount < 10),
+               Assert.ForTestFlow("test flow1", stats => stats.FailCount < 10),
+               Assert.ForStep("Flow name 1", "step name 10", stats => stats.FailCount == 95),
+               Assert.ForStep("Flow name 1", "step name 19", stats => Array.IndexOf(new [] { 80, 95}, stats.FailCount) > -1),
+               Assert.ForStep("Flow name 2", "step name 29", stats => stats.OkCount > 80 && stats.OkCount > 95)
+            };
+
+            ScenarioRunner.RunWithAssertions(scenario, asserts);
         }
     }
 }

--- a/examples/NBomber.Examples.CSharp/Scenarios/HttpScenario.cs
+++ b/examples/NBomber.Examples.CSharp/Scenarios/HttpScenario.cs
@@ -29,21 +29,8 @@ namespace NBomber.Examples.CSharp.Scenarios.Http
                     : Response.Fail(response.StatusCode.ToString());
             });
 
-            var asserts = new [] {
-               Assert.ForScenario(stats => stats.OkCount > 95),
-               Assert.ForScenario(stats => stats.FailCount > 95),
-               Assert.ForScenario(stats => stats.ExceptionCount > 95),
-               Assert.ForScenario(stats => stats.OkCount >= 95),
-               Assert.ForTestFlow("Flow name 23", stats => stats.FailCount < 10),
-               Assert.ForTestFlow("test flow1", stats => stats.FailCount < 10),
-               Assert.ForStep("Flow name 1", "step name 10", stats => stats.FailCount == 95),
-               Assert.ForStep("Flow name 1", "step name 19", stats => Array.IndexOf(new [] { 80, 95}, stats.FailCount) > -1),
-               Assert.ForStep("Flow name 2", "step name 29", stats => stats.OkCount > 80 && stats.OkCount > 95)
-            };           
-
             return new ScenarioBuilder(scenarioName: "Test HTTP (https://github.com) with 100 concurrent users")                
-                .AddTestFlow("GET flow", steps: new[] { step1 }, concurrentCopies: 100)
-                .AddAssertions(asserts)            
+                .AddTestFlow("GET flow", steps: new[] { step1 }, concurrentCopies: 100)          
                 .Build(duration: TimeSpan.FromSeconds(10));
         }
     }

--- a/examples/NBomber.Examples.FSharp/Program.fs
+++ b/examples/NBomber.Examples.FSharp/Program.fs
@@ -19,6 +19,6 @@ let main argv =
        Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> stats.OkCount > 80 && stats.OkCount > 95)
     |]
     
-    Scenario.runWithAssertions(HttpScenario.buildScenario(), assertions)
+    HttpScenario.buildScenario() |> Scenario.runWithAssertions(assertions)
 
     0 // return an integer exit code

--- a/examples/NBomber.Examples.FSharp/Program.fs
+++ b/examples/NBomber.Examples.FSharp/Program.fs
@@ -1,11 +1,24 @@
 ﻿open NBomber
 open NBomber.FSharp
 open NBomber.Examples.FSharp.Scenarios
+open NBomber
 
 [<EntryPoint>]
 let main argv =
+    let assertions = [|
+       Assert.forScenario(fun stats -> stats.OkCount > 95)
+       Assert.forScenario(fun stats -> false)
+       Assert.forScenario(fun stats -> stats.FailCount > 95)
+       Assert.forScenario(fun stats -> stats.OkCount > 0)
+       Assert.forScenario(fun stats -> stats.OkCount > 0)
+       Assert.forScenario(fun stats -> stats.OkCount > 95)
+       Assert.forTestFlow("GET flow1", fun stats -> stats.FailCount < 10)
+       Assert.forTestFlow("GET flow", fun stats -> false)
+       Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> false)
+       Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> Seq.exists (fun i -> i = stats.FailCount) [80;95])
+       Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> stats.OkCount > 80 && stats.OkCount > 95)
+    |]
     
-    HttpScenario.buildScenario() 
-    |> Scenario.run
-    
+    Scenario.runWithAssertions(HttpScenario.buildScenario(), assertions)
+
     0 // return an integer exit code

--- a/examples/NBomber.Examples.FSharp/Scenarios/HttpScenario.fs
+++ b/examples/NBomber.Examples.FSharp/Scenarios/HttpScenario.fs
@@ -24,22 +24,7 @@ let private step1 =
                         return if response.IsSuccessStatusCode then Response.Ok()
                                else Response.Fail(response.StatusCode.ToString()) })
 
-let private asserts = [
-   Assert.forScenario(fun stats -> stats.OkCount > 95)
-   Assert.forScenario(fun stats -> false)
-   Assert.forScenario(fun stats -> stats.FailCount > 95)
-   Assert.forScenario(fun stats -> stats.OkCount > 0)
-   Assert.forScenario(fun stats -> stats.OkCount > 0)
-   Assert.forScenario(fun stats -> stats.OkCount > 95)
-   Assert.forTestFlow("GET flow1", fun stats -> stats.FailCount < 10)
-   Assert.forTestFlow("GET flow", fun stats -> false)
-   Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> false)
-   Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> Seq.exists (fun i -> i = stats.FailCount) [80;95])
-   Assert.forStep("GET flow", "GET github.com/VIP-Logic/NBomber html", fun stats -> stats.OkCount > 80 && stats.OkCount > 95)
-]
-
 let buildScenario () =
     Scenario.create("Test HTTP (https://github.com) with 100 concurrent users")
-    |> Scenario.addTestFlow({ FlowName = "GET flow"; Steps = [step1]; ConcurrentCopies = 100 })
-    |> Scenario.addAssertions(asserts)    
+    |> Scenario.addTestFlow({ FlowName = "GET flow"; Steps = [step1]; ConcurrentCopies = 100 })   
     |> Scenario.withDuration(TimeSpan.FromSeconds(10.0))

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -6,6 +6,7 @@ open System.Threading.Tasks
 
 open NBomber.Contracts
 open NBomber.FSharp
+open NBomber
 
 type Step =    
     static member CreateRequest(name: string, execute: Func<Request,Task<Response>>) = Step.createRequest(name, execute.Invoke)
@@ -14,15 +15,14 @@ type Step =
     static member CreateListenerChannel() = Step.createListenerChannel()
 
 type Assert =
-    static member ForScenario (assertion: Func<AssertionStats, bool>) = Assertion.Scenario(assertion.Invoke)
-    static member ForTestFlow (flowName, assertion: Func<AssertionStats, bool>) = Assertion.TestFlow(flowName, assertion.Invoke)
-    static member ForStep (flowName, stepName, assertion: Func<AssertionStats, bool>) = Assertion.Step(flowName, stepName, assertion.Invoke)
+    static member ForScenario (assertion: Func<AssertionStats, bool>) = Assert.forScenario(assertion.Invoke)
+    static member ForTestFlow (flowName, assertion: Func<AssertionStats, bool>) = Assert.forTestFlow(flowName, assertion.Invoke)
+    static member ForStep (flowName, stepName, assertion: Func<AssertionStats, bool>) = Assert.forStep(flowName, stepName, assertion.Invoke)
 
 type ScenarioBuilder(scenarioName: string) =
     
     let flows = Dictionary<string, TestFlow>()
-    let mutable testInit = None
-    let mutable asserts = Array.empty        
+    let mutable testInit = None       
 
     member x.AddTestInit(initFunc: Func<Request,Task<Response>>) =
         let step = Step.CreateRequest(NBomber.Domain.Constants.InitId, initFunc)        
@@ -36,10 +36,6 @@ type ScenarioBuilder(scenarioName: string) =
                            
         flows.[flowConfig.FlowName] <- flowConfig
         x
-        
-    member x.AddAssertions(assertions : Assertion[]) =
-        asserts <- assertions
-        x
          
     member x.Build(duration: TimeSpan): Scenario =
         let flowConfigs = flows
@@ -51,4 +47,4 @@ type ScenarioBuilder(scenarioName: string) =
           TestInit = testInit
           TestFlows = flowConfigs          
           Duration = duration
-          Assertions = asserts }
+          Assertions = Array.empty }

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -6,6 +6,7 @@ open System.Runtime.InteropServices
 
 open NBomber
 open NBomber.Contracts
+open NBomber.ScenarioRunner
 
 module Step =
     open NBomber.Domain
@@ -22,9 +23,11 @@ module Step =
     let createListenerChannel () = StepListenerChannel() :> IStepListenerChannel
 
 module Assert =
-    let forScenario (assertion: AssertionStats -> bool) = Assertion.Scenario(assertion)
-    let forTestFlow (flowName, assertion: AssertionStats -> bool) = Assertion.TestFlow(flowName, assertion)
-    let forStep (flowName, stepName, assertion: AssertionStats -> bool) = Assertion.Step(flowName, stepName, assertion)
+    open NBomber.Domain 
+
+    let forScenario (assertion: AssertionStats -> bool) = Scenario(assertion) :> IAssertion
+    let forTestFlow (flowName, assertion: AssertionStats -> bool) = TestFlow(flowName, assertion) :> IAssertion
+    let forStep (flowName, stepName, assertion: AssertionStats -> bool) = Step(flowName, stepName, assertion) :> IAssertion
 
 module Scenario =
     
@@ -45,7 +48,9 @@ module Scenario =
     let withDuration (duration: TimeSpan) (scenario: Scenario) =
         { scenario with Duration = duration }
 
-    let addAssertions(assertions: Assertion list) (scenario: Scenario) =
-        { scenario with Assertions = assertions |> Seq.toArray }
+    let run (scenario: Scenario) = Run(scenario, true) |> ignore
 
-    let run (scenario: Scenario) = ScenarioRunner.Run(scenario)
+    let runWithAssertions (scenario: Scenario, assertions: IAssertion []) =
+        RunWithAssertions(scenario, assertions, true) |> ignore
+
+    let print (scenario: Scenario, assertions: IAssertion []) = Print(scenario, assertions)

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -50,7 +50,7 @@ module Scenario =
 
     let run (scenario: Scenario) = Run(scenario, true) |> ignore
 
-    let runWithAssertions (scenario: Scenario, assertions: IAssertion []) =
+    let runWithAssertions (assertions: IAssertion []) (scenario: Scenario) =
         RunWithAssertions(scenario, assertions, true) |> ignore
 
-    let print (scenario: Scenario, assertions: IAssertion []) = Print(scenario, assertions)
+    let print (assertions: IAssertion []) (scenario: Scenario) = Print(scenario, assertions)

--- a/src/NBomber/Contracts.fs
+++ b/src/NBomber/Contracts.fs
@@ -15,7 +15,9 @@ type Response = {
     Payload: obj
 }
 
-type IStep = interface end    
+type IStep = interface end   
+
+type IAssertion = interface end  
 
 type IStepListenerChannel =
     abstract Notify: correlationId:string * response:Response -> unit
@@ -31,7 +33,7 @@ type Scenario = {
     TestInit: IStep option
     TestFlows: TestFlow[]   
     Duration: TimeSpan
-    Assertions: Assertion[]
+    Assertions: IAssertion[]
 }
 
 type AssertionStats = {
@@ -41,17 +43,7 @@ type AssertionStats = {
     FailCount: int
     ExceptionCount: int
     ThrownException: exn option
-} with
-  static member Create (stepName, flowName, okCount, failCount, exceptionCount, exn) =
-      { StepName = stepName; FlowName = flowName; OkCount = okCount; FailCount = failCount;
-        ExceptionCount = exceptionCount; ThrownException = exn}
-
-type AssertionFunc = AssertionStats -> bool
-
-type Assertion = 
-    | Step     of stepName:string * flowName:string * AssertionFunc
-    | TestFlow of flowName:string * AssertionFunc
-    | Scenario of AssertionFunc
+}
 
 type AssertionResult =
     | Success

--- a/src/NBomber/Infra/ScenarioRunner.fs
+++ b/src/NBomber/Infra/ScenarioRunner.fs
@@ -69,12 +69,12 @@ let private runScenario (config: Contracts.Scenario, assertions: Contracts.IAsse
 
             Log.Information("{Scenario} has finished", scenario.ScenarioName)
 
-        let assertionStats = results
-                            |> Array.collect (fun flow -> flow.Steps |> Array.map(fun step -> (flow, step)))
-                            |> Array.map(fun (flow, step) -> createAssertionStats(flow.FlowName, step))
-        
-        applyAssertions(scenario.ScenarioName, assertionStats, scenario.Assertions) |> printAssertionResults                  
-    
+        results
+        |> Array.collect (fun flow -> flow.Steps |> Array.map(fun step -> (flow, step)))
+        |> Array.map(fun (flow, step) -> createAssertionStats(flow.FlowName, step))
+        |> applyAssertions(scenario.ScenarioName, scenario.Assertions)
+        |> printAssertionResults 
+         
     | Error e -> let message = Errors.printError(e)
                  Log.Error(message)
                  [|message|]

--- a/src/NBomber/Infra/ScenarioRunner.fs
+++ b/src/NBomber/Infra/ScenarioRunner.fs
@@ -11,62 +11,78 @@ open FSharp.Control.Tasks.V2.ContextInsensitive
 
 open NBomber.Errors
 open NBomber.Domain
+open NBomber.Domain.Assertions
 open NBomber.Statistics
 open NBomber.FlowRunner
+open System.Runtime.InteropServices
 
-let Run (scenario: Contracts.Scenario) =
+let Run (scenario: Contracts.Scenario,  [<Optional;DefaultParameterValue(true:bool)>]isVerbose: bool) =
+    runScenario(scenario, Array.empty, isVerbose)
+
+let RunWithAssertions (scenario: Contracts.Scenario, assertions: Contracts.IAssertion[], [<Optional;DefaultParameterValue(true:bool)>]isVerbose: bool) =
+    runScenario(scenario, assertions, isVerbose)
+
+let Print (scenario: Contracts.Scenario, assertions: Contracts.IAssertion[]) =
+    runWithRepeat(scenario, assertions)
+
+let private runWithRepeat (scenario: Contracts.Scenario, assertions: Contracts.IAssertion[]) =
     let mutable runningScenario = true
     while runningScenario do
-        runScenario(scenario)
+        runScenario(scenario, assertions, true) |> ignore
 
         Log.Information("Repeat the same Scenario one more time? (y/n)")
         let userInput = Console.ReadLine()
         runningScenario <- Seq.contains userInput ["y"; "Y"; "yes"; "Yes"]
 
-let private runScenario (config: Contracts.Scenario) = 
+let private runScenario (config: Contracts.Scenario, assertions: Contracts.IAssertion[], isVerbose: bool) = 
     
-    initLogger() 
+    if isVerbose then initLogger() 
 
-    let scenario = Scenario.create(config)
+    let scenario = Scenario.create(config, assertions)
 
     Log.Information("{Scenario} has started", config.ScenarioName)
-
+    
     let result = Scenario.runInit(scenario)
                  |> Result.bind(Scenario.warmUpScenario)
                  |> Result.map(startFlows) 
     
     match result with
     | Ok actorsHosts ->
-
         Log.Information("wait {time} until the execution ends", scenario.Duration.ToString())
         Log.Information("processing...")
         
         let t1 = Task.Delay(scenario.Duration)
-        let t2 = runProgressBar(scenario.Duration)
+        let t2 = if isVerbose then runProgressBar(scenario.Duration) else Task.FromResult(())
         Task.WhenAll(t1, t2).Wait()
-        
+
         stopFlows(actorsHosts)
 
         // wait until the flow runners stop
-        Task.Delay(TimeSpan.FromSeconds(1.0)).Wait()
+        Task.Delay(TimeSpan.FromSeconds(1.0)).Wait()    
+        let results = getResults(actorsHosts) 
+
+        if isVerbose then 
+            Log.Information("building report")
+            Reporting.buildReport(scenario, results)    
+            |> Reporting.saveReport
+            |> Log.Information
+
+            Log.Information("{Scenario} has finished", scenario.ScenarioName)
+
+        let assertionStats = results
+                            |> Array.collect (fun flow -> flow.Steps |> Array.map(fun step -> (flow, step)))
+                            |> Array.map(fun (flow, step) -> createAssertionStats(flow.FlowName, step))
         
-        let results = getResults(actorsHosts)        
-                                                                                       
-        let assertionData = results |> Array.collect (fun f -> f.Steps |> Array.map(fun step -> Contracts.AssertionStats.Create(step.StepName, f.FlowName, step.OkCount,
-                                                                                                    step.FailCount, step.ExceptionCount, step.ThrownException)))
+        applyAssertions(scenario.ScenarioName, assertionStats, scenario.Assertions) |> printAssertionResults                  
+    
+    | Error e -> let message = Errors.printError(e)
+                 Log.Error(message)
+                 [|message|]
 
-        let assertionResults = Assertions.apply(scenario.ScenarioName, assertionData, scenario.Assertions)
-        for result in assertionResults do Log.Error(result)
-
-        Log.Information("building report")
-        Reporting.buildReport(scenario, results)    
-        |> Reporting.saveReport
-        |> Log.Information
-
-        Log.Information("{Scenario} has finished", scenario.ScenarioName)
-
-    | Error e -> let msg = Errors.printError(e)
-                 Log.Error(msg) 
+let private initLogger () =
+    Log.Logger <- LoggerConfiguration()
+                .WriteTo.Console()
+                .CreateLogger()
 
 let private startFlows (scenario: Scenario) =
     Log.Information("starting test flows")
@@ -79,12 +95,7 @@ let private stopFlows (runner: FlowRunner[]) =
     runner |> Array.iter(fun x -> x.Stop())
 
 let private getResults (runner: FlowRunner[]) =
-    runner |> Array.map(fun x -> x.GetResult())    
-
-let private initLogger () =
-    Log.Logger <- LoggerConfiguration()
-                .WriteTo.Console()
-                .CreateLogger()
+    runner |> Array.map(fun x -> x.GetResult())
 
 let private runProgressBar (scenarioDuration: TimeSpan) = task {    
     let options = ProgressBarOptions(ProgressBarOnBottom = true,                                     
@@ -100,3 +111,11 @@ let private runProgressBar (scenarioDuration: TimeSpan) = task {
         do! Task.Delay(TimeSpan.FromSeconds(1.0))
         pbar.Tick()
 }
+
+let private createAssertionStats (flowName: string, step: StepInfo) =
+    { StepName = step.StepName; FlowName = flowName; OkCount = step.OkCount; FailCount = step.FailCount;
+        ExceptionCount = step.ExceptionCount; ThrownException = step.ThrownException }
+
+let private printAssertionResults (assertionResults: string[]) =
+    for assertionResult in assertionResults do Log.Error(assertionResult)
+    assertionResults


### PR DESCRIPTION
Preparation before XUnit and NUnit integration (integration is going to be in a separate PR)

- Adding `print()` and `runWithAssertions()` methods to `ScenarioRunner`
 Example of usage C#:
`ScenarioRunner.RunWithAssertions(scenario, assertions); \\ run with output to the console`
`ScenarioRunner.Run(scenario, false); \\ run with output to the console without assertions`
`ScenarioRunner.Print(scenario, assertions); \\  run scenario; printing stats to the file; repeat scenario`

 Example of usage F#:
  `Scenario.runWithAssertions(HttpScenario.buildScenario(), assertions) \\ run with output to the console`
  `scenario |> ScenarioRunner.run \\ run with output to the console without assertions`
   `ScenarioRunner.print(scenario, asserts) \\ run scenario; print stats to the file; repeat scenario`


- Adding `IAsseriton ` interfcase to hide domain DU from the clients

- Adding `isVerbose `flag to scenario runner indicating that there is no need to print anything to the console