### PR TITLE
fix compiler warning about AspNetCore version

### DIFF
--- a/examples/Infra/TestServer/TestServer.csproj
+++ b/examples/Infra/TestServer/TestServer.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />    
   </ItemGroup>
 


### PR DESCRIPTION
compiler warnings says it is not recommended to set a version of AspNetCore package. Probably it should fit the used SDK