### PR TITLE
Invariant CSV export

### DIFF
--- a/src/NBomber/DomainServices/Reports/CsvReport.fs
+++ b/src/NBomber/DomainServices/Reports/CsvReport.fs
@@ -31,7 +31,7 @@ let private getLine (scenarioName: string, duration: TimeSpan, stats: StepStats,
     let lt = stats.Ok.Latency
     let dt = stats.Ok.DataTransfer
 
-    String.Format(format,
+    String.Format(System.Globalization.CultureInfo.InvariantCulture, format,
                   testInfo.TestSuite, testInfo.TestName,
                   scenarioName, duration, stats.StepName,
                   reqCount, okCount, failCount,


### PR DESCRIPTION
using invariant culture to avoid issues reading CSV in cultures using comma as decimal separator