### PR TITLE
#509 Dedicated Console logger

### DIFF
--- a/src/NBomber/Constants.fs
+++ b/src/NBomber/Constants.fs
@@ -5,7 +5,7 @@ open Microsoft.Extensions.Configuration
 open NBomber.Contracts.Stats
 
 [<Literal>]
-let Logo = "NBomber"
+let Logo = "NBomber 4"
 [<Literal>]
 let NBomberWelcomeText = "NBomber {0} Started a new session: {1}"
 

--- a/src/NBomber/Constants.fs
+++ b/src/NBomber/Constants.fs
@@ -27,7 +27,7 @@ let DefaultTestName = "nbomber_default_test_name"
 [<Literal>]
 let DefaultReportName = "nbomber_report"
 [<Literal>]
-let DefaultReportFolder = "./reports"
+let DefaultReportFolder = "reports"
 [<Literal>]
 let ScenarioGlobalInfo = "global information"
 

--- a/src/NBomber/Domain/Scenario.fs
+++ b/src/NBomber/Domain/Scenario.fs
@@ -196,7 +196,7 @@ let inline measure (name: string) (ctx: ScenarioContext) (run: IScenarioContext 
         let latency = endTime - startTime
 
         let context = ctx :> IScenarioContext
-        context.Logger.Fatal(ex, $"Unhandled exception for Scenario: {0}", context.ScenarioInfo.ScenarioName)
+        context.Logger.Error(ex, $"Unhandled exception for Scenario: {0}", context.ScenarioInfo.ScenarioName)
 
         let response = ResponseInternal.failUnhandled ex
         let result = { Name = name; ClientResponse = response; EndTimeMs = endTime; LatencyMs = latency }

--- a/src/NBomber/Domain/Step.fs
+++ b/src/NBomber/Domain/Step.fs
@@ -34,7 +34,7 @@ let inline measure (name: string) (ctx: ScenarioContext) (run: unit -> Task<Resp
         let latency = endTime - startTime
 
         let context = ctx :> IScenarioContext
-        context.Logger.Fatal(ex, $"Unhandled exception for Scenario: {0}, Step: {1}", context.ScenarioInfo.ScenarioName, name)
+        context.Logger.Error(ex, $"Unhandled exception for Scenario: {0}, Step: {1}", context.ScenarioInfo.ScenarioName, name)
 
         let response = ResponseInternal.failUnhandled ex
         let result = { Name = name; ClientResponse = response; EndTimeMs = endTime; LatencyMs = latency }

--- a/src/NBomber/DomainServices/Reports/ReportHelper.fs
+++ b/src/NBomber/DomainServices/Reports/ReportHelper.fs
@@ -2,6 +2,7 @@ module internal NBomber.DomainServices.Reports.ReportHelper
 
 open System
 open NBomber.Contracts
+open NBomber.Contracts.Internal
 open NBomber.Contracts.Stats
 open NBomber.Extensions.Internal
 open NBomber.Domain
@@ -12,6 +13,12 @@ let printDataKb (highlightTxt: obj -> string) (bytes: int) =
 
 let printAllData (highlightTxt: obj -> string) (bytes: int64) =
     $"{bytes |> Converter.fromBytesToMb |> highlightTxt} MB"
+
+let getFullReportsFolderPath (sessionArgs: SessionArgs) =
+    let strExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location
+    let strWorkPath = System.IO.Path.GetDirectoryName strExeFilePath
+    let reportFolder = sessionArgs.GetReportFolder()
+    System.IO.Path.Combine(strWorkPath, reportFolder)
 
 module StepStats =
 

--- a/src/NBomber/DomainServices/TestHost/ReportingManager.fs
+++ b/src/NBomber/DomainServices/TestHost/ReportingManager.fs
@@ -10,7 +10,7 @@ open NBomber.Domain
 open NBomber.Domain.LoadSimulation
 open NBomber.Domain.Stats.Statistics
 open NBomber.Domain.Scheduler.ScenarioScheduler
-open NBomber.Infra.Dependency
+open NBomber.Infra
 
 type IReportingManager =
     inherit IDisposable
@@ -39,7 +39,7 @@ let getFinalStats (dep: IGlobalDependency)
 
     let nodeStats = NodeStats.create testInfo nodeInfo scenarioStats
 
-    let! pluginStats = WorkerPlugins.getStats dep.Logger dep.WorkerPlugins nodeStats
+    let! pluginStats = WorkerPlugins.getStats dep nodeStats
     return { nodeStats with PluginStats = pluginStats }
 }
 

--- a/src/NBomber/DomainServices/TestHost/ReportingSinks.fs
+++ b/src/NBomber/DomainServices/TestHost/ReportingSinks.fs
@@ -1,39 +1,38 @@
 module internal NBomber.DomainServices.TestHost.ReportingSinks
 
-open Serilog
 open FsToolkit.ErrorHandling
 open NBomber
 open NBomber.Contracts
 open NBomber.Contracts.Stats
 open NBomber.Errors
 open NBomber.Extensions.Internal
-open NBomber.Infra.Dependency
+open NBomber.Infra
 
 //todo: add Polly for timout and retry logic, using cancel token
-let init (dep: IGlobalDependency) (context: IBaseContext) (sinks: IReportingSink list) = taskResult {
+let init (dep: IGlobalDependency) (context: IBaseContext) = taskResult {
     try
-        for sink in sinks do
-            dep.Logger.Information("Start init reporting sink: {SinkName}", sink.SinkName)
+        for sink in dep.ReportingSinks do
+            dep.LogInfo("Start init reporting sink: {0}", sink.SinkName)
             do! sink.Init(context, dep.InfraConfig |> Option.defaultValue Constants.EmptyInfraConfig)
     with
     | ex -> return! AppError.createResult(InitScenarioError ex)
 }
 
-let start (logger: ILogger) (sinks: IReportingSink list) =
-    for sink in sinks do
+let start (dep: IGlobalDependency) =
+    for sink in dep.ReportingSinks do
         try
             sink.Start() |> ignore
         with
-        | ex -> logger.Warning(ex, "Failed to start reporting sink: {SinkName}", sink.SinkName)
+        | ex -> dep.LogWarn(ex, "Failed to start reporting sink: {0}", sink.SinkName)
 
 //todo: add Polly for timout and retry logic, using cancel token
-let stop (logger: ILogger) (sinks: IReportingSink list) = backgroundTask {
-    for sink in sinks do
+let stop (dep: IGlobalDependency) = backgroundTask {
+    for sink in dep.ReportingSinks do
         try
-            logger.Information("Stop reporting sink: {SinkName}", sink.SinkName)
+            dep.LogInfo("Stop reporting sink: {0}", sink.SinkName)
             do! sink.Stop()
         with
-        | ex -> logger.Warning(ex, "Failed to stop reporting sink: {SinkName}", sink.SinkName)
+        | ex -> dep.LogWarn(ex, "Failed to stop reporting sink: {0}", sink.SinkName)
 }
 
 let saveRealtimeStats (dep: IGlobalDependency) (stats: ScenarioStats[]) = backgroundTask {
@@ -42,7 +41,7 @@ let saveRealtimeStats (dep: IGlobalDependency) (stats: ScenarioStats[]) = backgr
             try
                 do! sink.SaveRealtimeStats stats
             with
-            | ex -> dep.Logger.Fatal(ex, "Reporting sink: {SinkName} failed to save scenario stats", sink.SinkName)
+            | ex -> dep.LogWarn(ex, "Reporting sink: {0} failed to save realtime scenario stats", sink.SinkName)
 }
 
 let saveFinalStats (dep: IGlobalDependency) (finalStats: NodeStats) = backgroundTask {
@@ -51,5 +50,5 @@ let saveFinalStats (dep: IGlobalDependency) (finalStats: NodeStats) = background
             try
                 do! sink.SaveFinalStats finalStats
             with
-            | ex -> dep.Logger.Fatal(ex, "Reporting sink: {SinkName} failed to save scenario stats", sink.SinkName)
+            | ex -> dep.LogWarn(ex, "Reporting sink: {0} failed to save final scenario stats", sink.SinkName)
 }

--- a/src/NBomber/DomainServices/TestHost/TestHost.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHost.fs
@@ -15,7 +15,6 @@ open NBomber.Contracts
 open NBomber.Contracts.Stats
 open NBomber.Contracts.Internal
 open NBomber.Extensions.Internal
-open NBomber.Errors
 open NBomber.Domain
 open NBomber.Domain.DomainTypes
 open NBomber.Domain.ScenarioContext
@@ -23,15 +22,12 @@ open NBomber.Domain.Stats
 open NBomber.Domain.Stats.ScenarioStatsActor
 open NBomber.Domain.Scheduler.ScenarioScheduler
 open NBomber.Infra
-open NBomber.Infra.Dependency
 open NBomber.DomainServices
 open NBomber.DomainServices.TestHost.ReportingManager
 
 type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as this =
 
-    let _log = dep.Logger.ForContext<TestHost>()
     let mutable _currentSchedulers = List.empty<ScenarioScheduler>
-
     let mutable _stopped = false
     let mutable _disposed = false
     let mutable _targetScenarios = List.empty<Scenario>
@@ -53,12 +49,12 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
 
         let createScheduler (scn: Scenario) =
             let scnDep = {
-                Logger = _log
+                Logger = dep.Logger
                 Scenario = scn
                 ScenarioCancellationToken = new CancellationTokenSource()
                 ScenarioTimer = Stopwatch()
                 ScenarioOperation = operation
-                ScenarioStatsActor = createStatsActor _log scn (_sessionArgs.GetReportingInterval())
+                ScenarioStatsActor = createStatsActor dep.Logger scn (_sessionArgs.GetReportingInterval())
                 ExecStopCommand = this.ExecStopCommand
                 TestInfo = _sessionArgs.TestInfo
                 GetNodeInfo = getCurrentNodeInfo
@@ -77,8 +73,8 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
         let isWarmUp = reportingManager.IsNone
 
         if not isWarmUp then
-            dep.WorkerPlugins |> WorkerPlugins.start _log
-            dep.ReportingSinks |> ReportingSinks.start _log
+            WorkerPlugins.start dep
+            ReportingSinks.start dep
 
         use consoleCancelToken = new CancellationTokenSource()
         TestHostConsole.LiveStatusTable.display dep consoleCancelToken.Token isWarmUp schedulers
@@ -97,8 +93,8 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
             // waiting (in case of cluster) on all raw stats
             do! reportingManager.Value.Stop()
 
-            do! dep.WorkerPlugins |> WorkerPlugins.stop _log
-            do! dep.ReportingSinks |> ReportingSinks.stop _log
+            do! WorkerPlugins.stop dep
+            do! ReportingSinks.stop dep
 
         if isWarmUp then
             GC.Collect()
@@ -107,10 +103,10 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
 
     let startInit (consoleStatus: StatusContext option) (sessionArgs: SessionArgs) = taskResult {
 
-        let baseContext = NBomberContext.createBaseContext sessionArgs.TestInfo getCurrentNodeInfo _log
+        let baseContext = NBomberContext.createBaseContext sessionArgs.TestInfo getCurrentNodeInfo dep.Logger
 
-        do! dep.WorkerPlugins |> WorkerPlugins.init dep baseContext
-        do! dep.ReportingSinks |> ReportingSinks.init dep baseContext
+        do! WorkerPlugins.init dep baseContext
+        do! ReportingSinks.init dep baseContext
 
         return! TestHostScenario.initScenarios dep consoleStatus baseContext sessionArgs regScenarios
     }
@@ -119,7 +115,7 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
                    (consoleStatus: StatusContext option)
                    (scenarios: Scenario list) =
 
-        let baseContext = NBomberContext.createBaseContext sessionArgs.TestInfo getCurrentNodeInfo _log
+        let baseContext = NBomberContext.createBaseContext sessionArgs.TestInfo getCurrentNodeInfo dep.Logger
         let enabledScenarios = scenarios |> List.filter(fun x -> x.IsEnabled)
         TestHostScenario.cleanScenarios dep consoleStatus baseContext enabledScenarios
 
@@ -135,21 +131,23 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
         _currentOperation <- OperationType.Init
 
         TestHostConsole.printContextInfo dep
-        _log.Information "Starting init..."
+        dep.LogInfo "Starting init..."
 
         TestHostConsole.displayStatus dep "Initializing scenarios..." (fun consoleStatus -> backgroundTask {
-            match! startInit consoleStatus sessionArgs with
+            let! initResult = startInit consoleStatus sessionArgs
+            match initResult with
             | Ok initializedScenarios ->
-                _log.Information "Init finished"
+                dep.LogInfo "Init finished"
+
                 _targetScenarios  <- initializedScenarios
                 _sessionArgs      <- sessionArgs
                 _currentOperation <- OperationType.None
+
                 return Ok _targetScenarios
 
-            | Error appError ->
-                _log.Error "Init failed"
+            | Error _ ->
                 _currentOperation <- OperationType.Stop
-                return AppError.createResult appError
+                return initResult
         })
 
     member _.StartWarmUp(scenarios: Scenario list, ?getScenarioClusterCount: ScenarioName -> int) = backgroundTask {
@@ -159,14 +157,14 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
         let warmupScenarios = Scenario.getScenariosForWarmUp scenarios
         if warmupScenarios.Length > 0 then
 
-            _log.Information "Starting warm up..."
+            dep.LogInfo "Starting warm up..."
 
             let warmUpSchedulers = this.CreateScenarioSchedulers(
                 warmupScenarios, ScenarioOperation.WarmUp, ?getScenarioClusterCount = getScenarioClusterCount
             )
 
             let names = warmupScenarios |> Seq.map(fun x -> x.ScenarioName) |> String.concatWithComma
-            _log.Verbose $"Warm up for scenarios: [{names}]"
+            dep.Logger.Verbose $"Warm up for scenarios: [{names}]"
 
             _currentSchedulers <- warmUpSchedulers
 
@@ -181,7 +179,7 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
         _currentOperation <- OperationType.Bombing
         _currentSchedulers <- schedulers
 
-        _log.Information "Starting bombing..."
+        dep.LogInfo "Starting bombing..."
         do! startScenarios schedulers (Some reportingManager)
 
         do! this.StopAllScenarios()
@@ -196,7 +194,7 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
             |> List.tryFind(fun sch -> sch.Working && sch.Scenario.ScenarioName = scenarioName)
             |> Option.iter(fun sch ->
                 sch.Stop()
-                _log.Warning("Stopping scenario early: {ScenarioName}, reason: {StopReason}", sch.Scenario.ScenarioName, reason)
+                dep.LogWarn("Stopping scenario early: {0}, reason: {1}", sch.Scenario.ScenarioName, reason)
             )
 
         | StopTest reason -> this.StopAllScenarios(reason) |> ignore
@@ -206,9 +204,9 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
             _currentOperation <- OperationType.Stop
 
             if not(String.IsNullOrEmpty reason) then
-                _log.Warning("Stopping test early: {StopReason}", reason)
+                dep.LogWarn("Stopping test early: {0}", reason)
             else
-                _log.Information "Stopping scenarios..."
+                dep.LogInfo "Stopping scenarios..."
 
             TestHostConsole.displayStatus dep "Cleaning scenarios..." (fun consoleStatus -> backgroundTask {
                 stopSchedulers _currentSchedulers
@@ -260,7 +258,7 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
             do! this.StartBombing(bombingSchedulers, reportingManager)
 
             // gets final stats
-            _log.Information "Calculating final statistics..."
+            dep.LogInfo "Calculating final statistics..."
             return! reportingManager.GetSessionResult(getCurrentNodeInfo())
         else
             return NodeSessionResult.empty
@@ -278,8 +276,6 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
             for plugin in dep.WorkerPlugins do
                 use _ = plugin
                 ()
-
-            _log.Verbose $"{nameof TestHost} disposed"
 
     interface IDisposable with
         member _.Dispose() = this.Dispose()

--- a/src/NBomber/DomainServices/TestHost/TestHost.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHost.fs
@@ -130,7 +130,7 @@ type internal TestHost(dep: IGlobalDependency, regScenarios: Scenario list) as t
         _stopped <- false
         _currentOperation <- OperationType.Init
 
-        TestHostConsole.printContextInfo dep
+        TestHostConsole.printContextInfo dep sessionArgs
         dep.LogInfo "Starting init..."
 
         TestHostConsole.displayStatus dep "Initializing scenarios..." (fun consoleStatus -> backgroundTask {

--- a/src/NBomber/DomainServices/TestHost/TestHostConsole.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHostConsole.fs
@@ -13,35 +13,34 @@ open NBomber.Domain
 open NBomber.Domain.DomainTypes
 open NBomber.Domain.Scheduler.ScenarioScheduler
 open NBomber.Infra
-open NBomber.Infra.Dependency
 
 let printTargetScenarios (dep: IGlobalDependency) (targetScns: Scenario list) =
     targetScns
     |> List.map(fun x -> x.ScenarioName)
-    |> fun targets -> dep.Logger.Information("Target scenarios: {TargetScenarios}", String.concatWithComma targets)
+    |> fun targets -> dep.LogInfo("Target scenarios: {0}", String.concatWithComma targets)
 
 let displayStatus (dep: IGlobalDependency) (msg: string) (runAction: StatusContext option -> Task<'T>) =
     if dep.ApplicationType = ApplicationType.Console then
         let status = AnsiConsole.Status()
         status.StartAsync(msg, fun ctx -> runAction (Some ctx))
     else
-        dep.Logger.Information msg
+        dep.LogInfo msg
         runAction None
 
 let printContextInfo (dep: IGlobalDependency) =
-    dep.Logger.Verbose("NBomberConfig: {NBomberConfig}", $"%A{dep.NBomberConfig}")
+    dep.Logger.Verbose("NBomberConfig: {0}", $"%A{dep.NBomberConfig}")
 
     if dep.WorkerPlugins.IsEmpty then
-        dep.Logger.Information "Plugins: no plugins were loaded"
+        dep.LogInfo "Plugins: no plugins were loaded"
     else
         dep.WorkerPlugins
-        |> List.iter(fun plugin -> dep.Logger.Information("Plugin loaded: {PluginName}", plugin.PluginName))
+        |> List.iter(fun plugin -> dep.LogInfo("Plugin loaded: {0}", plugin.PluginName) )
 
     if dep.ReportingSinks.IsEmpty then
-        dep.Logger.Information "Reporting sinks: no reporting sinks were loaded"
+        dep.LogInfo "Reporting sinks: no reporting sinks were loaded"
     else
         dep.ReportingSinks
-        |> List.iter(fun sink -> dep.Logger.Information("Reporting sink loaded: {SinkName}", sink.SinkName))
+        |> List.iter(fun sink -> dep.LogInfo("Reporting sink loaded: {0}", sink.SinkName))
 
 module LiveStatusTable =
 

--- a/src/NBomber/DomainServices/TestHost/TestHostConsole.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHostConsole.fs
@@ -4,14 +4,18 @@ open System
 open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
+
 open FsToolkit.ErrorHandling
 open Spectre.Console
+
 open NBomber.Contracts
 open NBomber.Contracts.Stats
+open NBomber.Contracts.Internal
 open NBomber.Extensions.Internal
 open NBomber.Domain
 open NBomber.Domain.DomainTypes
 open NBomber.Domain.Scheduler.ScenarioScheduler
+open NBomber.DomainServices.Reports
 open NBomber.Infra
 
 let printTargetScenarios (dep: IGlobalDependency) (targetScns: Scenario list) =
@@ -27,7 +31,10 @@ let displayStatus (dep: IGlobalDependency) (msg: string) (runAction: StatusConte
         dep.LogInfo msg
         runAction None
 
-let printContextInfo (dep: IGlobalDependency) =
+let printContextInfo (dep: IGlobalDependency) (sessionArgs: SessionArgs) =
+    let reportsFolder = ReportHelper.getFullReportsFolderPath sessionArgs
+    dep.LogInfo("Reports folder: {0}", reportsFolder)
+
     dep.Logger.Verbose("NBomberConfig: {0}", $"%A{dep.NBomberConfig}")
 
     if dep.WorkerPlugins.IsEmpty then

--- a/src/NBomber/DomainServices/TestHost/TestHostScenario.fs
+++ b/src/NBomber/DomainServices/TestHost/TestHostScenario.fs
@@ -8,7 +8,6 @@ open NBomber.Domain
 open NBomber.Domain.DomainTypes
 open NBomber.Errors
 open NBomber.Infra
-open NBomber.Infra.Dependency
 
 let getTargetScenarios (sessionArgs: SessionArgs) (regScenarios: Scenario list) =
     regScenarios
@@ -26,7 +25,7 @@ let initEnabledScenarios (dep: IGlobalDependency)
         try
             for scn in enabledScenarios do
                 if scn.Init.IsSome then
-                    dep.Logger.Information("Start init scenario: {Scenario}", scn.ScenarioName)
+                    dep.LogInfo("Start init scenario: {0}", scn.ScenarioName)
 
                     if consoleStatus.IsSome then
                         consoleStatus.Value.Status <- $"Initializing scenario: {Console.okColor scn.ScenarioName}"
@@ -70,7 +69,7 @@ let cleanScenarios (dep: IGlobalDependency)
 
     for scn in enabledScenarios do
         if scn.Clean.IsSome then
-            dep.Logger.Information("Start cleaning scenario: {0}", scn.ScenarioName)
+            dep.LogInfo("Start cleaning scenario: {0}", scn.ScenarioName)
 
             if consoleStatus.IsSome then
                 consoleStatus.Value.Status <- $"Cleaning scenario: {Console.okColor scn.ScenarioName}"
@@ -80,5 +79,5 @@ let cleanScenarios (dep: IGlobalDependency)
             try
                 do! scn.Clean.Value context
             with
-            | ex -> dep.Logger.Warning(ex, "Cleaning scenario failed: {0}", scn.ScenarioName)
+            | ex -> dep.LogWarn(ex, "Cleaning scenario failed: {0}", scn.ScenarioName)
 }

--- a/tests/NBomber.IntegrationTests/Plugins/PluginTests.fs
+++ b/tests/NBomber.IntegrationTests/Plugins/PluginTests.fs
@@ -267,4 +267,4 @@ let ``PluginStats should return empty data set in case of internal exception`` (
     |> Result.getOk
     |> fun nodeStats ->
         test <@ Array.isEmpty nodeStats.PluginStats @>
-        inMemorySink.Should().HaveMessage("Getting plugin stats failed: {0}", "because exception was thrown") |> ignore
+        inMemorySink.Should().HaveMessage("Getting plugin stats failed", "because exception was thrown") |> ignore

--- a/tests/NBomber.IntegrationTests/TestHelper.fs
+++ b/tests/NBomber.IntegrationTests/TestHelper.fs
@@ -67,6 +67,7 @@ module internal Dependency =
                 member _.InfraConfig = dep.InfraConfig
                 member _.CreateLoggerConfig = dep.CreateLoggerConfig
                 member _.Logger = dep.Logger
+                member _.ConsoleLogger = dep.ConsoleLogger
                 member _.ReportingSinks = dep.ReportingSinks
                 member _.WorkerPlugins = dep.WorkerPlugins }
 


### PR DESCRIPTION
In NBomber v4, you will not be able to pollute your console output with irrelevant messages.
In v4, we changed the logger logic, and now we have two separate loggers:

**Console Logger** - which is managed by NBomber and will not be available for customization. Plus, this logger will not print any of your messages in the console. It only prints messages that were sent by the NBomber host.
**Client Logger** - this logger is provided to be used by clients. The client can fully customize this logger. By default, this logger writes logs in the file, but it can be changed/customized.

This commit also fixes the following:
- https://github.com/PragmaticFlow/NBomber/issues/519
- https://github.com/PragmaticFlow/NBomber/issues/509

