### PR TITLE
Adapt NBomber for int64 changes in NBomber.Contracts (#559)

### DIFF
--- a/examples/CSharpProd/DB/LiteDB/InitDBScenario.cs
+++ b/examples/CSharpProd/DB/LiteDB/InitDBScenario.cs
@@ -16,7 +16,7 @@ namespace CSharpProd.DB.LiteDB
     {
         public LiteDatabase Db { get; private set; }
         public ILiteCollection<User> Collection { get; private set; }
-        public int RecordSizeBytes { get; private set; }
+        public long RecordSizeBytes { get; private set; }
         public LiteDBCustomSettings DBSettings { get; private set;}
 
         public ScenarioProps Create()

--- a/src/NBomber/Api/CSharp.fs
+++ b/src/NBomber/Api/CSharp.fs
@@ -1,4 +1,4 @@
-﻿namespace NBomber.CSharp
+namespace NBomber.CSharp
 
 #nowarn "3211"
 
@@ -24,7 +24,7 @@ type Response =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Ok(
         [<Optional;DefaultParameterValue("")>] statusCode: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue("")>] message: string,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<obj> =
 
@@ -38,7 +38,7 @@ type Response =
     [<MethodImpl(MethodImplOptions.AggressiveInlining)>]
     static member Ok<'T>(
         [<Optional;DefaultParameterValue("")>] statusCode: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue("")>] message: string,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<'T> =
 
@@ -53,7 +53,7 @@ type Response =
     static member Ok<'T>(
         payload: 'T,
         [<Optional;DefaultParameterValue("")>] statusCode: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue("")>] message: string,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<'T> =
 
@@ -68,7 +68,7 @@ type Response =
     static member Fail(
         [<Optional;DefaultParameterValue("")>] statusCode: string,
         [<Optional;DefaultParameterValue("")>] message: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<obj> =
 
         { StatusCode = statusCode
@@ -82,7 +82,7 @@ type Response =
     static member Fail<'T>(
         [<Optional;DefaultParameterValue("")>] statusCode: string,
         [<Optional;DefaultParameterValue("")>] message: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<'T> =
 
         { StatusCode = statusCode
@@ -97,7 +97,7 @@ type Response =
         payload: 'T,
         [<Optional;DefaultParameterValue("")>] statusCode: string,
         [<Optional;DefaultParameterValue("")>] message: string,
-        [<Optional;DefaultParameterValue(0)>] sizeBytes: int,
+        [<Optional;DefaultParameterValue(0)>] sizeBytes: int64,
         [<Optional;DefaultParameterValue(0.0)>] latencyMs: float) : Response<'T> =
 
         { StatusCode = statusCode

--- a/src/NBomber/Api/FSharp.fs
+++ b/src/NBomber/Api/FSharp.fs
@@ -1,4 +1,4 @@
-﻿namespace NBomber.FSharp
+namespace NBomber.FSharp
 
 open System
 open System.IO
@@ -33,7 +33,7 @@ type Response =
     static member inline ok<'T>(
         ?payload: 'T,
         ?statusCode: string,
-        ?sizeBytes: int,
+        ?sizeBytes: int64,
         ?message: string,
         ?latencyMs: float) =
 
@@ -48,7 +48,7 @@ type Response =
         ?statusCode: string,
         ?message: string,
         ?payload: 'T,
-        ?sizeBytes: int,
+        ?sizeBytes: int64,
         ?latencyMs: float) =
 
         { StatusCode = statusCode |> Option.defaultValue ""

--- a/src/NBomber/Constants.fs
+++ b/src/NBomber/Constants.fs
@@ -42,7 +42,7 @@ let GetPluginStatsTimeout = TimeSpan.FromSeconds 5
 let OneSecond = TimeSpan.FromSeconds 1
 
 let MaxTrackableStepLatency = (1000L * TimeSpan.TicksPerMillisecond) * 60L * 10L // 10 min (in ticks)
-let MaxTrackableStepResponseSize = int64 Int32.MaxValue
+let MaxTrackableStepResponseSize = Int64.MaxValue
 
 [<Literal>]
 let ReportingTimerCompleteMs = 3_000

--- a/src/NBomber/Domain/Stats/RawMeasurementStats.fs
+++ b/src/NBomber/Domain/Stats/RawMeasurementStats.fs
@@ -18,8 +18,8 @@ type RawStatusCodeStats = {
 type RawItemStats = {
     mutable MinMicroSec: int
     mutable MaxMicroSec: int
-    mutable MinBytes: int
-    mutable MaxBytes: int
+    mutable MinBytes: int64
+    mutable MaxBytes: int64
     mutable RequestCount: int
     mutable LessOrEq800: int
     mutable More800Less1200: int
@@ -41,7 +41,7 @@ let empty (stepName) =
     let createStats () = {
         MinMicroSec = Int32.MaxValue
         MaxMicroSec = 0
-        MinBytes = Int32.MaxValue
+        MinBytes = Int64.MaxValue
         MaxBytes = 0
         RequestCount = 0
         LessOrEq800 = 0
@@ -57,7 +57,7 @@ let empty (stepName) =
       OkStats = createStats()
       FailStats = createStats() }
 
-let addMeasurement (rawStats: RawMeasurementStats) (measurement: Measurement) (finalDataSize) =
+let addMeasurement (rawStats: RawMeasurementStats) (measurement: Measurement) (finalDataSize: int64) =
 
     let updateStatusCodeStats (statuses: Dictionary<string,RawStatusCodeStats>, res: IResponse) =
         match statuses.TryGetValue res.StatusCode with
@@ -109,8 +109,8 @@ let addMeasurement (rawStats: RawMeasurementStats) (measurement: Measurement) (f
 
         // add data transfer
         if finalDataSize > 0 then
-            stats.AllBytes <- stats.AllBytes + int64 finalDataSize
-            stats.DataTransferHistogram.RecordValue(int64 finalDataSize)
+            stats.AllBytes <- stats.AllBytes + finalDataSize
+            stats.DataTransferHistogram.RecordValue(finalDataSize)
 
             if finalDataSize < stats.MinBytes then
                 stats.MinBytes <- finalDataSize

--- a/src/NBomber/Domain/Stats/ScenarioStatsActor.fs
+++ b/src/NBomber/Domain/Stats/ScenarioStatsActor.fs
@@ -1,4 +1,4 @@
-﻿module internal NBomber.Domain.Stats.ScenarioStatsActor
+module internal NBomber.Domain.Stats.ScenarioStatsActor
 
 open System
 open System.Collections.Generic
@@ -29,7 +29,7 @@ type State = {
     MergeStatsFn: (LoadSimulationStats -> ScenarioStats seq -> ScenarioStats) option
     mutable ScenarioFailCount: int
     StepsOrder: Dictionary<string, int>
-    GlobalInfoDataSize: ResizeArray<int>
+    GlobalInfoDataSize: ResizeArray<int64>
 
     ReportingStatsCache: Dictionary<TimeSpan,ScenarioStats>
     CoordinatorStepsResults: Dictionary<string,RawMeasurementStats>

--- a/src/NBomber/Domain/Stats/Statistics.fs
+++ b/src/NBomber/Domain/Stats/Statistics.fs
@@ -72,12 +72,12 @@ module DataTransferStats =
             else ValueNone
 
         { MinBytes  = if dataTransfer.IsSome then stats.MinBytes else 0
-          MeanBytes = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.mean |> int else 0
+          MeanBytes = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.mean |> int64 else 0
           MaxBytes  = if dataTransfer.IsSome then stats.MaxBytes else 0
-          Percent50 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(50.0) |> int else 0
-          Percent75 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(75.0) |> int else 0
-          Percent95 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(95.0) |> int else 0
-          Percent99 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(99.0) |> int else 0
+          Percent50 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(50.0) |> int64 else 0
+          Percent75 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(75.0) |> int64 else 0
+          Percent95 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(95.0) |> int64 else 0
+          Percent99 = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.getPercentile(99.0) |> int64 else 0
           StdDev    = if dataTransfer.IsSome then dataTransfer.Value |> Histogram.stdDev |> Converter.round(Constants.StatsRounding) else 0.0
           AllBytes  = stats.AllBytes }
 

--- a/src/NBomber/DomainServices/Reports/CsvReport.fs
+++ b/src/NBomber/DomainServices/Reports/CsvReport.fs
@@ -16,7 +16,7 @@ let private getHeader () =
      "data_transfer_min_kb"; "data_transfer_mean_kb"; "data_transfer_max_kb"; "data_transfer_all_mb"]
     |> String.concat(separator)
 
-let private toKb (bytes: int) =
+let private toKb (bytes: int64) =
     bytes |> Converter.fromBytesToKb
 
 let private toMb (bytes: int64) =

--- a/src/NBomber/DomainServices/Reports/ReportHelper.fs
+++ b/src/NBomber/DomainServices/Reports/ReportHelper.fs
@@ -8,7 +8,7 @@ open NBomber.Extensions.Internal
 open NBomber.Domain
 open NBomber.Domain.Stats
 
-let printDataKb (highlightTxt: obj -> string) (bytes: int) =
+let printDataKb (highlightTxt: obj -> string) (bytes: int64) =
     $"{bytes |> Converter.fromBytesToKb |> highlightTxt} KB"
 
 let printAllData (highlightTxt: obj -> string) (bytes: int64) =


### PR DESCRIPTION
This completes support for int64 data sizes. Please note that it requires an updated `NBomber.Contracts` NuGet.