### PR TITLE
Bump FsToolkit.ErrorHandling.TaskResult version

### DIFF
--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -17,7 +17,7 @@
         <ServerGarbageCollection>true</ServerGarbageCollection>
         <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <Title>NBomber</Title>        
+        <Title>NBomber</Title>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="AssemblyInfo.fs" />
@@ -73,7 +73,7 @@
     <ItemGroup>
         <PackageReference Include="NBomber.Contracts" Version="[4.1.1]" />
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
-        <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="2.13.0" />
+        <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.5.0" />
         <PackageReference Include="FuncyDown" Version="1.3.0" />
         <PackageReference Include="HdrHistogram" Version="2.5.0" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />


### PR DESCRIPTION
Bump version to prevent incompatible assembly using.
```
Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Ply, Version=0.3.1.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.

File name: 'Ply, Version=0.3.1.0, Culture=neutral, PublicKeyToken=null'
   at NBomber.DomainServices.NBomberRunner.runSession(TestInfo testInfo, NodeInfo nodeInfo, NBomberContext context, IGlobalDependency dep)
   at NBomber.DomainServices.NBomberRunner.run(Boolean disposeLogger, NBomberContext context)
   at NBomber.FSharp.NBomberRunner.runWithResult(IEnumerable`1 args, NBomberContext context)
   at NBomber.FSharp.NBomberRunner.run(NBomberContext context)
   at <StartupCode$NBomberTest>.$Program.main@() in /**/NBomberTest/NBomberTest/Program.fs:line 12

Process finished with exit code 134.
```

Code:
```fsharp
open NBomber.FSharp

let scenario =
    Scenario.create("test", fun ctx -> task { return Response.ok() })
    |> Scenario.withoutWarmUp
    |> Scenario.withLoadSimulations [LoadSimulation.Inject(100, TimeSpan.FromSeconds 1., TimeSpan.FromMinutes 1.)]
    
let result =
    [scenario]
    |> NBomberRunner.registerScenarios
    |> NBomberRunner.run

printfn $"{result}"
```

fsproj:
```
<Project Sdk="Microsoft.NET.Sdk">

    <PropertyGroup>
        <OutputType>Exe</OutputType>
        <TargetFramework>net7.0</TargetFramework>
    </PropertyGroup>

    <ItemGroup>
        <Compile Include="Program.fs" />
    </ItemGroup>

    <ItemGroup>
      <PackageReference Include="FsToolkit.ErrorHandling.TaskResult" Version="4.5.0" />
      <PackageReference Include="NBomber" Version="4.1.2" />
    </ItemGroup>

</Project>
```