### PR TITLE
Fixing a latency row name in export files, except HTML

### DIFF
--- a/src/NBomber/DomainServices/Reports/ReportHelper.fs
+++ b/src/NBomber/DomainServices/Reports/ReportHelper.fs
@@ -56,8 +56,8 @@ module StepStats =
         [ if stepIndex > 0 then [String.Empty; String.Empty]
           ["name"; blueColor stats.StepName]
           ["request count"; reqCount]
-          ["latency"; latencies]
-          ["latency percentile"; percentiles]
+          ["latency, ms"; latencies]
+          ["latency percentile, ms"; percentiles]
           if data.DataTransfer.AllBytes > 0 then ["data transfer"; dataTransfer] ]
 
 module LoadSimulation =


### PR DESCRIPTION
The latency row in some of result export files wasn't specifying the units of time, so I did it the same way it was already done in HTML export variant. Here is the result in these types of export files:
Before:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/3c88898d-69b9-40b3-8943-40ffe59a3ba9)
After:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/8116aea7-15c7-4ddb-b9ff-273a827592d9)
Before:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/27b8696f-b0d1-460f-b2a7-833ad13ac8c1)
After:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/33fd0cd9-88cd-48ed-b744-8c1ca7c9cf1c)
Before:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/7e68bf6c-545b-4f9c-8dac-a7dd2915b4d9)
After:
![изображение](https://github.com/PragmaticFlow/NBomber/assets/84920429/57113b5b-2ba3-4c78-912c-3729c2fec9d8)
