### PR TITLE
Update hint message for Response class usage

### DIFF
--- a/src/NBomber/Domain/HintsAnalyzer.fs
+++ b/src/NBomber/Domain/HintsAnalyzer.fs
@@ -6,7 +6,7 @@ let private analyzeDataTransfer (scnStats: ScenarioStats) =
 
     let printHint (scnName, stepName) =
         $"Step: '{stepName}' in Scenario: '{scnName}' didn't track data transfer." +
-        " In order to track data transfer, you should use Response.Ok(sizeInBytes: value)"
+        " In order to track data transfer, you should use Response.Ok(sizeBytes: value)"
 
     scnStats.StepStats
     |> Seq.filter(fun step -> step.Ok.DataTransfer.MinBytes + step.Fail.DataTransfer.MinBytes = 0)


### PR DESCRIPTION
This change makes the hint message argument name consistent with https://github.com/PragmaticFlow/NBomber.Contracts/blob/dev/src/NBomber.Contracts/Response.fs

`sizeInBytes` -> `sizeBytes`