### PR TITLE
Switch to Serilog.Sinks.Spectre

### DIFF
--- a/src/NBomber/Infra/Dependency.fs
+++ b/src/NBomber/Infra/Dependency.fs
@@ -9,7 +9,7 @@ open System.Runtime.Versioning
 open Microsoft.Extensions.Configuration
 open Serilog
 open Serilog.Events
-open Serilog.Sinks.SpectreConsole
+open Serilog.Sinks.Spectre
 
 open NBomber.Configuration
 open NBomber.Contracts
@@ -135,7 +135,7 @@ module internal Logger =
     let createConsoleLogger () =
         let outputTemplate = "{Timestamp:HH:mm:ss} [{Level:u3}] {Message:lj}{NewLine}{Exception}"
         let config = LoggerConfiguration()
-        config.WriteTo.SpectreConsole(outputTemplate, minLevel = LogEventLevel.Information) |> ignore
+        config.WriteTo.Spectre(outputTemplate, restrictedToMinimumLevel = LogEventLevel.Information) |> ignore
         config.CreateLogger() :> ILogger
 
     let create (logSettings: LoggerInitSettings) (context: NBomberContext) =

--- a/src/NBomber/NBomber.fsproj
+++ b/src/NBomber/NBomber.fsproj
@@ -84,7 +84,7 @@
         <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="ConsoleTables" Version="2.4.2" />
-        <PackageReference Include="Serilog.Sinks.SpectreConsole" Version="[0.3.3]" />
+        <PackageReference Include="Serilog.Sinks.Spectre" Version="0.6.0" />
         <PackageReference Update="FSharp.Core" Version="7.0.0" />
         <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>


### PR DESCRIPTION
This allow us to use a Spectre.Console 0.55.0.

This should fix https://github.com/PragmaticFlow/NBomber/issues/981